### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP Memory Server with Qdrant Persistence
 
+[![smithery badge](https://smithery.ai/badge/@delorenj/mcp-qdrant-memory)](https://smithery.ai/server/@delorenj/mcp-qdrant-memory)
+
 This MCP server provides a knowledge graph implementation with semantic search capabilities powered by Qdrant vector database.
 
 ## Features
@@ -29,6 +31,14 @@ QDRANT_COLLECTION_NAME=your-collection-name
 ```
 
 ## Setup
+
+### Installing via Smithery
+
+To install Memory Server with Qdrant Persistence for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@delorenj/mcp-qdrant-memory):
+
+```bash
+npx -y @smithery/cli install @delorenj/mcp-qdrant-memory --client claude
+```
 
 1. Install dependencies:
 ```bash

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,28 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - openaiApiKey
+      - qdrantUrl
+      - qdrantCollectionName
+    properties:
+      openaiApiKey:
+        type: string
+        description: The API key for OpenAI to generate embeddings.
+      qdrantUrl:
+        type: string
+        description: The URL of the Qdrant server (supports both HTTP and HTTPS).
+      qdrantApiKey:
+        type: string
+        description: The API key for Qdrant (if authentication is enabled).
+      qdrantCollectionName:
+        type: string
+        description: The name of the Qdrant collection to use.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({ command: 'node', args: ['dist/index.js'], env: { OPENAI_API_KEY: config.openaiApiKey, QDRANT_URL: config.qdrantUrl, QDRANT_API_KEY: config.qdrantApiKey, QDRANT_COLLECTION_NAME: config.qdrantCollectionName } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@delorenj/mcp-qdrant-memory?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂